### PR TITLE
[PA-699] Fix broken links and add text for users

### DIFF
--- a/ckanext/issues/lib/helpers.py
+++ b/ckanext/issues/lib/helpers.py
@@ -1,6 +1,9 @@
 from math import ceil
 
-from pylons import config
+try:
+    from ckan.common import config
+except ImportError:
+    from pylons import config
 
 from ckan import model
 from ckan.plugins import toolkit
@@ -222,3 +225,13 @@ def issues_user_is_owner(user, dataset_id):
         authorized = False
 
     return authorized
+
+def issues_enabled_email_notifications():
+    notifications = False
+    try:
+        notifications = toolkit.asbool(
+            config.get('ckanext.issues.send_email_notifications')
+        )
+    except (ValueError, KeyError):
+        return False
+    return notifications

--- a/ckanext/issues/plugin.py
+++ b/ckanext/issues/plugin.py
@@ -48,6 +48,8 @@ class IssuesPlugin(p.SingletonPlugin):
                 helpers.issues_user_is_owner,
             'issues_users_who_reported_issue':
                 helpers.issues_users_who_reported_issue,
+            'issues_enabled_email_notifications':
+                helpers.issues_enabled_email_notifications,
         }
 
     # IRoutes

--- a/ckanext/issues/templates/issues/add.html
+++ b/ckanext/issues/templates/issues/add.html
@@ -28,8 +28,12 @@ set           {% for key, error in c.error_summary.items() %}
     {{ form.markdown('description', label=_('Description'), id='field-description', placeholder=_('Add a comment'), value=data.description, error=errors.description) }}
     {#{{ form.input('resource', label=_('Resource'), id='resource', attrs={'disabled':'1'}) }} ]#}
   {% endblock %}
-
   <div class="form-actions">
+    {% if h.issues_enabled_email_notifications() %}
+      <p class="action-info small">
+        Once an issue has been reported an administrator will be notified. Please check back for updates and resolutions.
+      </p>
+    {% endif %}
     {{ h.nav_link(_('Cancel'), controller='related', action='list', id=c.id,
     class_='btn') }}
     <button class="btn btn-primary" type="submit" name="save" tabindex="4">{{ _('Create') }}</button>

--- a/ckanext/issues/templates/issues/base_form_page.html
+++ b/ckanext/issues/templates/issues/base_form_page.html
@@ -14,7 +14,7 @@
     <h2 class="module-heading"><i class="icon-info-sign"></i> {{ _('What are issues?') }}</h2>
     <div class="module-content">
       {% trans %}
-        <p>Issues are ... .</p>
+        <p>Issues are used to report data quality issues.</p>
       {% endtrans %}
     </div>
   </section>

--- a/ckanext/issues/templates/issues/common.html
+++ b/ckanext/issues/templates/issues/common.html
@@ -26,7 +26,7 @@
           </li>
           <li>
             <i class="icon-comments"></i>
-            <a href="{{issue.ckan_url}}">
+            <a href="{{ h.url_for('issues_show', dataset_id=pkg.id, issue_number=issue.number) }}">
               {{ _('%s comments') % (issue.comment_count) }}
             </a>
           </li>

--- a/ckanext/issues/templates/issues/dataset.html
+++ b/ckanext/issues/templates/issues/dataset.html
@@ -15,32 +15,39 @@
 
 {% block primary_content_inner %}
 <section class="module issues-home">
-    <div class="header">
-      <h1 class="page-heading">
-        {{ _('Issues') }}
-        <div class="issues-actions">
-          {{ h.nav_link(_('New Issue'), named_route='issues_new', dataset_id=pkg.name, class_='btn btn-success') }}
-        </div>
-      </h1>
-   <div>
+  <div class="header">
+    <h1 class="page-heading">
+      {{ _('Issues') }}
+      <div class="issues-actions">
+        {{ h.nav_link(_('New Issue'), named_route='issues_new', dataset_id=pkg.name, class_='btn btn-success') }}
+      </div>
+    </h1>
+    <div>
       {% snippet 'snippets/search_form.html', type='issue', query=q, fields=(('page', pagination.page), ('per_page', pagination.per_page), ('status', status), ('visibility', visibility)), sorting=filters, sorting_selected=sort, placeholder=_('Search issues...'), no_bottom_border=true, no_title=true %}
       <h2 id="issues-found">
         {{ ungettext('{number} issue found', '{number} issues found', pagination.total_count) .format(number=pagination.total_count) }}
       </h2>
     </div>
-  {% if issues %}
-    <ul id="issue-list" class="issue-list-group list-group">
-      {% for issue in issues %}
-        {{ common.issue_item(issue, pkg, c.user) }}
-      {% endfor %}
-    </ul>
-  {% else %}
-    <p class="empty">{{ _('No issues') }}</p>
-  {% endif %}
+    {% if issues %}
+      <ul id="issue-list" class="issue-list-group list-group">
+        {% for issue in issues %}
+          {{ common.issue_item(issue, pkg, c.user) }}
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="empty">{{ _('No issues') }}</p>
+    {% endif %}
   </div>
 
   {{ common.page_selector(pagination, issues_per_page, url_params={'dataset_id': pkg['id']}) }}
 </section>
+{% if h.issues_enabled_email_notifications() %}
+  <section class="module module-narrow">
+    <p>
+      Once an issue has been reported an administrator will be notified. Please check back for updates and resolutions.
+    </p>
+  </section>
+{% endif %}
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckanext/issues/templates/issues/organization_issues.html
+++ b/ckanext/issues/templates/issues/organization_issues.html
@@ -45,7 +45,7 @@
             </thead>
             <tbody>
             {% for issue in issues %}
-             {% set issue_url = issue.ckan_url %}
+             {% set issue_url = h.url_for('issues_show', dataset_id=issue.dataset_id, issue_number=issue.number) %}
               <tr class="{{'success' if issue.resolved else 'error'}}">
                 <td>
                   <a href="{{ issue_url }}">


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [TICKET](https://opengovinc.atlassian.net/browse/PA-699)

## Description
<!--- Describe these changes in detail --->
This PR address engineering support tickets [ESN-253](https://opengovinc.atlassian.net/browse/ESN-253) and [ESN-289](https://opengovinc.atlassian.net/browse/ESN-289).

For ESN-253 we're adding text to the issues tab and the add issue form to inform users that org admins will be notified of new issues. The added text is "`Once an issue has been reported an administrator will be notified. Please check back for updates and resolutions.`". This text should only appear if the following has been set in the ini `ckanext.issues.send_email_notifications = true`.

For ESN-289 we're fixing broken links so that they direct users to the linked issue.

## Test Procedure
<!--- List the steps involved to test the changes --->
- Checkout this PR and install the issues extension by adding `issues` to the plugin list
- Go to a dataset and click on the issues tab.
- Check that there is no text  at the bottom.
- Add `ckanext.issues.send_email_notifications = true` to the ini, restart CKAN, and check that the text `Once an issue ...` is present now.
- Add a new issue, leave a comment, and go back to the dataset issue tab.
- Click on the comment link and check that it directs you to the issue.
![Screen Shot 2019-09-05 at 6 15 36 PM](https://user-images.githubusercontent.com/4096633/64387565-5f61b500-d00a-11e9-9c50-0002c4456ea9.png)


## Approval Criteria 
<!--- Describe the expected results of testing --->